### PR TITLE
Lets test together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.40 and up
 
+## [0.42.1] - Point-release
+
+- Nothing done but this changelog amending
+
 ## [0.42.0] - Bugfixes
 
 - Bugfixes and adding daily full-updating via [plugwise v0.33.0](https://github.com/plugwise/python-plugwise/releases/tag/v0.33.0)

--- a/RELEASE_HEAD.md
+++ b/RELEASE_HEAD.md
@@ -1,5 +1,17 @@
 # Plugwise Test
 
-Never use this code
+**Discard appropriately**
+# DO NOT INSTALL - unless you are requested to!
+# DO NOT INSTALL - For internal testing
+**/Discard appropriately**
 
-Changes in this release:
+## What's Changed
+
+### Breaking Changes 🛠
+
+### Home Assistant Core related 🏠
+
+### Bug Fixes 🐛
+
+### Maintenance 🧰 and other changes
+


### PR DESCRIPTION
If you can merge and afterwards 'tag' with `v0.42.1` let's see if it does the magic

And yes the template of the pre-release will have some 'afterwork' but rather shift headers than missing out on stuff or repeat them in our changelog. (As in, the eye candy is nice for the release and HACS - it's not relevant for the changelog)?